### PR TITLE
Fixed module requiring for Node environment

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,8 @@ module.exports = {
     path: path.join(__dirname, 'dist'),
     library: libraryName,
     libraryTarget: 'umd',
+    umdNamedDefine: true,
+    globalObject: 'typeof self !== \'undefined\' ? self : this',
   },
   module: {
     rules: [


### PR DESCRIPTION
<!-- Please provide enough information so that others may review your pull request. -->

### Summary

Fixes #2 
Solution provided by https://github.com/webpack/webpack/issues/6522#issuecomment-371120689

<!-- Describe, briefly, what this pull request does. -->

<!-- Then, describe the type of change of this pull request. -->
**Change Type:** bug fix

#### Current Behavior

Throws `ReferenceError` when requiring module in Node environments.

#### New Behavior

Module attaches itself to correct object.

#### Closes Issues

Closes #2 
